### PR TITLE
Fix "Undefined symbol 'STATETAB0' Value=0" in 07_testsnd.zsm

### DIFF
--- a/tutorials/07_testsnd.zsm
+++ b/tutorials/07_testsnd.zsm
@@ -29,7 +29,7 @@ L011c:  rts             ; Called when the COMM app loads new data - WRIST_NEWDAT
         nop
         nop
 
-L011f:  lda     STATETAB0,X ; The state table get routine - WRIST_GETSTATE
+L011f:  lda     TABLE0,X ; The state table get routine - WRIST_GETSTATE
         rts
 
 L0123:  jmp     DOEVENT0


### PR DESCRIPTION
Fixes https://github.com/synthead/timex-datalink-toebes-tutorials/issues/1!

From https://github.com/synthead/timex-datalink-toebes-tutorials/issues/1:

> When assembling [`07_testsnd.zsm`](https://github.com/synthead/timex-datalink-toebes-tutorials/blob/130329c38d58b6643eb9b285b0cfa57326d8285a/tutorials/07_testsnd.zsm), this error is raised:
> 
> ```
> Assembling 150 Version...
> Assembling 150S Version...
> /root/asm_file(32): Undefined symbol 'STATETAB0' Value=0
> L011f:  lda     STATETAB0,X ; The state table get routine - WRIST_GETSTATE
> ```
> 
> The Toebes' assembler [link to download](http://toebes.com/Datalink/asm6805.zip) includes the same tutorial programs, but they are a little different.  Most of the changes are simply comment and indent differences, but I noticed this in the zip file that isn't in the code in the [7 - Playing with Sound tutorial](http://toebes.com/Datalink/testsnd.html):
> 
> ```diff
> -L011f:  lda     STATETAB0,X ; The state table get routine - WRIST_GETSTATE
> -        rts
> +L011f:          lda     TABLE0,X
> +                rts
> ```
> 
> There is probably a bug in the version on the website, and this probably fixes said bug.
> 
> In addition, a ZAP file is still produced, but if it is synced to a 150, the watch resets its data and reboots when opening the program.