### PR TITLE
Fix Undefined symbol 'TIM_2_8TIC' Value=0 in 04_flash.zsm

### DIFF
--- a/tutorials/04_flash.zsm
+++ b/tutorials/04_flash.zsm
@@ -46,7 +46,7 @@ S6_SAMPLE:      timex6  "SAMPLE"
 ;
 STATETAB:
         db      0
-        db      EVT_ENTER,TIM_2_8TIC,0          ; Initial state
+        db      EVT_ENTER,TIM2_8TIC,0           ; Initial state
         db      EVT_TIMER2,TIM_ONCE,0           ; The timer from the enter event
         db      EVT_RESUME,TIM_ONCE,0           ; Resume from a nested app
         db      EVT_MODE,TIM_ONCE,$FF           ; Mode button


### PR DESCRIPTION
Fixes https://github.com/synthead/timex-datalink-toebes-tutorials/issues/5!

This is the same fix as https://github.com/synthead/timex-datalink-toebes-tutorials/pull/4, but for `04_flash.zsm` :boom: 

From https://github.com/synthead/timex-datalink-toebes-tutorials/pull/4:

> Fixes https://github.com/synthead/timex-datalink-toebes-tutorials/issues/3!
> 
> Replaces `TIM_2_8TIC` with `TIM2_8TIC` in `03_update.zsm`.
> 
> This one is a little interesting!  The `TIM_2_8TIC` symbol actually exists in the include file inside the [Wristapp.i for the 150](http://toebes.com/Datalink/Wristapp.zip) zip archive from http://toebes.com/Datalink/wristapps.html:
> 
> ```assembly
> TIM_2_8TIC      EQU     $83     ; This is the normal blink interval
> ```
> 
> However, the `Wristapp.i` file from Toebes' assembler setup program (inside the zip archive [here](http://toebes.com/Datalink/asm6805.zip)) does not have the symbol `TIM_2_8TIC`.  Instead, it contains the `TIM2_8TIC` symbol, which looks to be renamed from `TIM_2_8TIC`:
> 
> ```assembly
> TIM2_8TIC       EQU     $83     ; This is the normal blink interval
> ```
> 
> Additionally, `TIM_2_8TIC` does not exist in the include file inside the [Wristapp.i for the 150s](http://toebes.com/Datalink/wristapps.zip) zip archive.  It also contains a similar `TIM2_8TIC`:
> 
> ```assembly
> TIM2_8TIC       EQU     $83     ; This is the normal blink interval
> ```
> 
> Since there's different versions of this include file floating around, I thought I'd check the date stamps of the file in the [Wristapp.i for the 150](http://toebes.com/Datalink/Wristapp.zip) zip archive vs the file inside the setup program:
> 
> |Location|Date|
> |---|---|
> |Assembler archive|Aug 9th 1997|
> |Wristapp.i for the 150|May 10th 1997|
> 
> Since the include file in the assembler archive is newer, and the same symbol is also available for the 150s in the  assembler archive, I'm going to assume that this symbol was renamed after May 10th, 1997 from `TIM_2_8TIC` to `TIM2_8TIC`, and that the file in the [Wristapp.i for the 150](http://toebes.com/Datalink/Wristapp.zip) zip archive is out-of-date.
> 
> From https://github.com/synthead/timex-datalink-toebes-tutorials/issues/3:
> 
> > When assembling [`03_update.zsm`](https://github.com/synthead/timex-datalink-toebes-tutorials/blob/b7b9679420e937ef5a8f34642773e4e2b3e480ed/tutorials/03_update.zsm), this error is raised:
> > 
> > ```
> > Assembling 150 Version...
> > Assembling 150S Version...
> > /root/asm_file(49): Undefined symbol 'TIM_2_8TIC' Value=0
> >         db      EVT_ENTER,TIM_2_8TIC,0          ; Initial state
> > ```
> > 
> > The Toebes' assembler [link to download](http://toebes.com/Datalink/asm6805.zip) includes the same tutorial programs, but they are a little different.  Most of the changes are simply comment and indent differences, but I noticed this in the zip file that isn't in the code in the [3 - Better Input](http://toebes.com/Datalink/update.html):
> > 
> > ```diff
> > -        db      EVT_ENTER,TIM_2_8TIC,0          ; Initial state
> > +        db      EVT_ENTER,TIM2_8TIC,0           ; Initial state
> > ```
> > 
> > There is probably a bug in the version on the website, and this probably fixes said bug.