### PR TITLE
Use bsr CHECKSTATE in HANDLE_STATE0 in 08_endoff.zsm

### DIFF
--- a/tutorials/08_endoff.zsm
+++ b/tutorials/08_endoff.zsm
@@ -73,7 +73,7 @@ HANDLE_STATE0:
         lda     #ROW_T5H
         sta     DISP_ROW
         bset    COL_T5H,DISP_COL
-        jsr     CHECKSTATE              ; Just for fun, check the alarm state
+        bsr     CHECKSTATE              ; Just for fun, check the alarm state
         lda     #S8_TOEBES-START
         jmp     BANNER8
 ;


### PR DESCRIPTION
Fixes https://github.com/synthead/timex-datalink-toebes-tutorials/issues/9!

> When assembling `08_endoff.zsm`, this error is returned from the assembler:
> 
> ```
> Assembling 150 Version...
> Assembling 150S Version...
> /root/asm_file(76): JSR could be replaced with a BSR (distance=12)
>         jsr     CHECKSTATE              ; Just for fun, check the alarm state
> ```